### PR TITLE
tell npm to publish bin alongside src and dist.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "browser": "dist/bundle.min.js",
   "files": [
     "dist",
-    "src"
+    "src",
+    "bin"
   ],
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Since there's command line usage to this library, we need to publish `bin` as well.

Follow on from #5.